### PR TITLE
Picture-in-Picture APIに非対応のブラウザではvideoそのものを表示する

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,15 @@
                 </div>
             </div>
         </form>
+        <div class="pb-2" id="video-container" hidden>
+            <video
+                id="video-timer"
+                width="440"
+                height="240"
+                muted
+                autoPictureInPicture
+            ></video>
+        </div>
         <div class="py-2">
             <p>
                 使い方は<a href="help.html">こちら</a>

--- a/js/main.js
+++ b/js/main.js
@@ -11,15 +11,25 @@ function formatTime(leftSeconds) {
     return `${zeroPad(minutes, 2)} : ${zeroPad(seconds, 2)}`;
 }
 
-async function createVideo(canvasEl) {
-    const video = document.createElement('video');
-    video.muted = true;
+async function loadVideo(canvasEl) {
+    const video = document.getElementById("video-timer");
     video.srcObject = canvasEl.captureStream();
-    video.autoPictureInPicture = true;
+}
+
+async function playVideo() {
+    const video = document.getElementById("video-timer");
     video.play();
-    video.addEventListener('loadedmetadata', () => {
+
+    if (video.requestPictureInPicture !== undefined) {
+        // Chromeなど、Picture-in-Picture APIに対応しているブラウザであれば
+        // そのままPicture-in-Pictureモードに入る
         video.requestPictureInPicture();
-    });
+    } else {
+        // Firefoxなど、Picture-in-Picture APIに対応していないブラウザであれば
+        // ビデオそのものを画面に表示する
+        const videoContainer = document.getElementById("video-container");
+        videoContainer.hidden = false;
+    }
 }
 
 async function playBeep() {
@@ -58,6 +68,7 @@ class Timer {
     init() {
         const text = formatTime(this.leftSeconds);
         this.writeToCanvas(text);
+        loadVideo(this.canvasEl);
     }
     start() {
         if (this.isPlaying) {
@@ -79,7 +90,7 @@ class Timer {
             const text = formatTime(this.leftSeconds);
             this.writeToCanvas(text);
         }, 1000);
-        createVideo(this.canvasEl);
+        playVideo();
         this.isPlaying = true;
         this.isPause = false;
     }
@@ -108,6 +119,8 @@ class Timer {
             this.canvasCtx.font = this.fontSizeTimeOver + ' ' + this.font;
         }
         this.canvasCtx.clearRect(0, 0, this.canvasEl.width, this.canvasEl.height);
+        this.canvasCtx.fillStyle = "black";
+        this.canvasCtx.fillRect(0, 0, this.canvasEl.width, this.canvasEl.height);
         this.canvasCtx.textAlign = 'center';
         this.canvasCtx.fillStyle = "#" + this.fontColor;
         this.canvasCtx.fillText(text, this.canvasEl.width / 2, this.canvasEl.height / 2);


### PR DESCRIPTION
Firefox (を始めとする `requestPictureInPicture()` APIに非対応のブラウザ) ではビデオ本体を表示するようにしてみました。

ビデオが実際に表示されていさえすれば、Firefoxでもこのように右クリックすることでPicture in Picture表示を呼び出すことができます。Chromeのような即Picture in Pictureに入れるブラウザに比べて利便性は落ちますが、使えないよりは便利です。

![image](https://github.com/mh326/picture_in_picture_timer/assets/20490597/3893ece3-c834-4a59-a15a-37ffd98d31d1)

Chrome上での見かけ上の動作は変えていないつもりですが、ロードのタイミングなどを変えているので問題があればご指摘ください。
また、ローカルではFirefoxとChromeで動作確認をしていますが、Notion埋め込みなどのケースでも問題なく動くかどうかは確認できておりません...。

Close #1 .